### PR TITLE
Update night.json

### DIFF
--- a/night.json
+++ b/night.json
@@ -164,7 +164,7 @@
                 "name": "Dusk"
             },
             {
-                "description": "Start the night."
+                "description": "Check that all eyes are closed. Some Fabled act."
             },
             {
                 "default_alignment": "Neither"
@@ -192,7 +192,7 @@
                 "name": "Alchemist"
             },
             {
-                "description": "Show the YOU ARE token and the Character token of a not in play Minion"
+                "description": "Show the YOU ARE token & the Character token of a not in play Minion"
             },
             {
                 "default_alignment": "Good"
@@ -206,7 +206,7 @@
                 "name": "Poppy Grower"
             },
             {
-                "description": "Do not do the Minion Info and Demon Info steps. Wake the Demon, show the THESE CHARACTERS ARE NOT IN PLAY info token and any three good character tokens that are not in play."
+                "description": "Do not do the Minion Info & Demon Info steps. Wake the Demon, show the THESE CHARACTERS ARE NOT IN PLAY info token & any three good character tokens that are not in play."
             },
             {
                 "default_alignment": "Good"
@@ -220,7 +220,7 @@
                 "name": "Magician"
             },
             {
-                "description": "Include the Magician in the Minion and Demon Info steps."
+                "description": "Include the Magician in the Minion & Demon Info steps."
             },
             {
                 "default_alignment": "Good"
@@ -248,7 +248,7 @@
                 "name": "Snitch"
             },
             {
-                "description": "Wake each Minion. Show the THESE CHARACTERS ARE NOT IN PLAY token and three not-in-play character tokens. Put each Minion to sleep."
+                "description": "Wake each Minion. Show the THESE CHARACTERS ARE NOT IN PLAY token & three not-in-play character tokens. Put each Minion to sleep."
             },
             {
                 "default_alignment": "Good"
@@ -262,7 +262,7 @@
                 "name": "Lunatic"
             },
             {
-                "description": "If there are 7 or more players, wake the Lunatic: Show the THESE ARE YOUR MINIONS token. Point to any players. Show the THESE CHARACTERS ARE NOT IN PLAY token. Show 3 good character tokens. Put the Lunatic to sleep. Wake the Demon. Show the YOU ARE info token and the Demon token. Show the THIS PLAYER IS info token and the Lunatic token, then point to the Lunatic."
+                "description": "If there are 7 or more players, wake the Lunatic: Show the THESE ARE YOUR MINIONS token. Point to any players. Show the THESE CHARACTERS ARE NOT IN PLAY token. Show 3 good character tokens. Put the Lunatic to sleep. Wake the Demon. Show the YOU ARE info token & the Demon token. Show the THIS PLAYER IS info token & the Lunatic token, then point to the Lunatic."
             },
             {
                 "default_alignment": "Good"
@@ -290,7 +290,7 @@
                 "name": "King"
             },
             {
-                "description": "Wake the Demon. Show the THIS PLAYER IS token and the King Token, then point to the King."
+                "description": "Wake the Demon. Show the THIS PLAYER IS token & the King Token, then point to the King."
             },
             {
                 "default_alignment": "Good"
@@ -318,7 +318,7 @@
                 "name": "Marionette"
             },
             {
-                "description": "Wake the Demon. Point to the player marked IS THE MARIONETTE and show the THIS PLAYER IS token and the Marionette character token."
+                "description": "Wake the Demon. Point to the player marked IS THE MARIONETTE & show the THIS PLAYER IS token & the Marionette character token."
             },
             {
                 "default_alignment": "Evil"
@@ -332,7 +332,7 @@
                 "name": "Engineer"
             },
             {
-                "description": "The Engineer might choose Minions or Demons. \u26ab If they do: \n\tPut the Engineer to sleep. Wake a targer, show them the YOU ARE token and their new character token, then put that target to sleep. Repeat for all players that changed characters."
+                "description": "The Engineer might choose Minions or Demons. \u26ab If they do: \n\tPut the Engineer to sleep. Wake a targer, show them the YOU ARE token & their new character token, then put that target to sleep. Repeat for all players that changed characters."
             },
             {
                 "default_alignment": "Good"
@@ -346,7 +346,7 @@
                 "name": "Preacher"
             },
             {
-                "description": "The Preacher chooses a player. \u26ab If they chose a Minion: \n\tPut the Preacher to sleep. Wake the target. Show the THIS CHARACTER SELECTED YOU token and the Preacher token."
+                "description": "The Preacher chooses a player. \u26ab If they chose a Minion: \n\tPut the Preacher to sleep. Wake the target. Show the THIS CHARACTER SELECTED YOU token & the Preacher token."
             },
             {
                 "default_alignment": "Good"
@@ -430,7 +430,7 @@
                 "name": "Snake Charmer"
             },
             {
-                "description": "The Snake Charmer chooses a player. If they chose the Demon: \n\tShow the YOU ARE & Demon tokens. Give a thumbs down. Swap the Snake Charmer & Demon tokens. Put the old Snake Charmer to sleep. Wake the old Demon. Show the YOU ARE and Snake Charmer tokens & give a thumbs up. \u26ab"
+                "description": "The Snake Charmer chooses a player. If they chose the Demon: \n\tShow the YOU ARE & Demon tokens. Give a thumbs down. Swap the Snake Charmer & Demon tokens. Put the old Snake Charmer to sleep. Wake the old Demon. Show the YOU ARE & Snake Charmer tokens & give a thumbs up. \u26ab"
             },
             {
                 "default_alignment": "Good"
@@ -612,7 +612,7 @@
                 "name": "Washerwoman"
             },
             {
-                "description": "Show the Townsfolk character token. Point to both the TOWNSFOLK and WRONG players."
+                "description": "Show the Townsfolk character token. Point to both the TOWNSFOLK & WRONG players."
             },
             {
                 "default_alignment": "Good"
@@ -626,7 +626,7 @@
                 "name": "Librarian"
             },
             {
-                "description": "Show the Outsider character token. Point to both the OUTSIDER and WRONG players."
+                "description": "Show the Outsider character token. Point to both the OUTSIDER & WRONG players."
             },
             {
                 "default_alignment": "Good"
@@ -640,7 +640,7 @@
                 "name": "Investigator"
             },
             {
-                "description": "Show the Minion character token. Point to both the MINION and WRONG players."
+                "description": "Show the Minion character token. Point to both the MINION & WRONG players."
             },
             {
                 "default_alignment": "Good"
@@ -738,7 +738,7 @@
                 "name": "Dreamer"
             },
             {
-                "description": "The Dreamer points to a player. Show 1 good and 1 evil character token, 1 of which is their character."
+                "description": "The Dreamer points to a player. Show 1 good & 1 evil character token, 1 of which is their character."
             },
             {
                 "default_alignment": "Good"
@@ -850,7 +850,7 @@
                 "name": "Nightwatchman"
             },
             {
-                "description": "The Nightwatchman might choose a player. \u26ab Put the Nightwatchman to sleep. Wake the target and show the THIS PLAYER IS and Nightwatchman tokens and point to the Nightwatchman."
+                "description": "The Nightwatchman might choose a player. \u26ab Put the Nightwatchman to sleep. Wake the target & show the THIS PLAYER IS & Nightwatchman tokens & point to the Nightwatchman."
             },
             {
                 "default_alignment": "Good"
@@ -864,7 +864,7 @@
                 "name": "Cult Leader"
             },
             {
-                "description": "The Cult Leader might change alignment. If so, show the YOU ARE info token and a thumbs up or down for their new alignment."
+                "description": "The Cult Leader might change alignment. If so, show the YOU ARE info token & a thumbs up or down for their new alignment."
             },
             {
                 "default_alignment": "Good"
@@ -948,7 +948,7 @@
                 "name": "Dawn"
             },
             {
-                "description": "Wait for a few seconds. End the Night Phase."
+                "description": "Wait for a few seconds. Call for eyes open."
             },
             {
                 "default_alignment": "Neither"
@@ -990,7 +990,7 @@
                 "name": "Travelers"
             },
             {
-                "description": "Tell any new travelers their alignment by showing the YOU ARE token and a thumbs up or down. If they are evil: \n\tShow the THIS IS THE DEMON token. Point to the Demon. Any night actions by travelers should be done now. "
+                "description": "Tell any new travelers their alignment by showing the YOU ARE token & a thumbs up or down. If they are evil: \n\tShow the THIS IS THE DEMON token. Point to the Demon. Any night actions by travelers should be done now. "
             },
             {
                 "default_alignment": "Neither"
@@ -1032,7 +1032,7 @@
                 "name": "Yaggababble"
             },
             {
-                "description": "Choose a secret phrase. Wake the Yaggababble and let them know their secret  phrase. "
+                "description": "Choose a secret phrase. Wake the Yaggababble & let them know their secret  phrase. "
             },
             {
                 "default_alignment": "Evil"
@@ -1074,7 +1074,7 @@
                 "name": "Lord Of Typhon"
             },
             {
-                "description": "Replace neighbors of the Lord of Typhon with Minions, wake them, tell them their new alignment and character, then do minion info."
+                "description": "Replace neighbors of the Lord of Typhon with Minions, wake them, tell them their new alignment & character, then do minion info."
             },
             {
                 "default_alignment": "Evil"
@@ -1088,7 +1088,7 @@
                 "name": "Boffin"
             },
             {
-                "description": "Wake the Boffin and the Demon. Show the not-in-play good character token. Put the Boffin and the Demon to sleep."
+                "description": "Wake the Boffin & the Demon. Show the not-in-play good character token. Put the Boffin & the Demon to sleep."
             },
             {
                 "default_alignment": "Evil"
@@ -1160,7 +1160,7 @@
                 "name": "Poppy Grower"
             },
             {
-                "description": "If the Poppy Grower died today or tonight, wake the Minions, show the THIS IS THE DEMON info token and point to the Demon. Put them to sleep. Wake the Demon, show the THESE ARE YOUR MINIONS info token and point to the minions. Put the Demon to sleep."
+                "description": "If the Poppy Grower died today or tonight, wake the Minions, show the THIS IS THE DEMON info token & point to the Demon. Put them to sleep. Wake the Demon, show the THESE ARE YOUR MINIONS info token & point to the minions. Put the Demon to sleep."
             },
             {
                 "default_alignment": "Good"
@@ -1188,7 +1188,7 @@
                 "name": "Engineer"
             },
             {
-                "description": "The Engineer might choose Minions or Demons. \u26ab If they do: \n\tPut the Engineer to sleep. Wake a targer, show them the YOU ARE token and their new character token, then put that target to sleep. Repeat for all players that changed characters."
+                "description": "The Engineer might choose Minions or Demons. \u26ab If they do: \n\tPut the Engineer to sleep. Wake a targer, show them the YOU ARE token & their new character token, then put that target to sleep. Repeat for all players that changed characters."
             },
             {
                 "default_alignment": "Good"
@@ -1202,7 +1202,7 @@
                 "name": "Preacher"
             },
             {
-                "description": "The Preacher chooses a player. \u26ab If they chose a Minion: \n\tPut the Preacher to sleep. Wake the target. Show the THIS CHARACTER SELECTED YOU token and the Preacher token."
+                "description": "The Preacher chooses a player. \u26ab If they chose a Minion: \n\tPut the Preacher to sleep. Wake the target. Show the THIS CHARACTER SELECTED YOU token & the Preacher token."
             },
             {
                 "default_alignment": "Good"
@@ -1272,7 +1272,7 @@
                 "name": "Snake Charmer"
             },
             {
-                "description": "The Snake Charmer chooses a player. If they chose the Demon: \n\tShow the YOU ARE & Demon tokens. Give a thumbs down. Swap the Snake Charmer & Demon tokens. Put the old Snake Charmer to sleep. Wake the old Demon. Show the YOU ARE and Snake Charmer tokens & give a thumbs up. \u26ab"
+                "description": "The Snake Charmer chooses a player. If they chose the Demon: \n\tShow the YOU ARE & Demon tokens. Give a thumbs down. Swap the Snake Charmer & Demon tokens. Put the old Snake Charmer to sleep. Wake the old Demon. Show the YOU ARE & Snake Charmer tokens & give a thumbs up. \u26ab"
             },
             {
                 "default_alignment": "Good"
@@ -1384,7 +1384,7 @@
                 "name": "Mezepheles"
             },
             {
-                "description": "If a player is marked with the TURNS EVIL reminder, wake them. Show the YOU ARE info token and a thumbs down. The Mezepheles loses their ability. \u26ab"
+                "description": "If a player is marked with the TURNS EVIL reminder, wake them. Show the YOU ARE info token & a thumbs down. The Mezepheles loses their ability. \u26ab"
             },
             {
                 "default_alignment": "Evil"
@@ -1538,7 +1538,7 @@
                 "name": "Fang Gu"
             },
             {
-                "description": "The Fang Gu chooses a player. \u26ab If they chose an Outsider (once only): \n\tReplace the Outsider token with the spare Fang Gu token. Put the Fang Gu token to sleep. Wake the target. Show the YOU ARE and Fang Gu tokens & give a thumbs-down. \u26ab"
+                "description": "The Fang Gu chooses a player. \u26ab If they chose an Outsider (once only): \n\tReplace the Outsider token with the spare Fang Gu token. Put the Fang Gu token to sleep. Wake the target. Show the YOU ARE & Fang Gu tokens & give a thumbs-down. \u26ab"
             },
             {
                 "default_alignment": "Evil"
@@ -1608,7 +1608,7 @@
                 "name": "Al-Hadikhia"
             },
             {
-                "description": "The Al-Hadikhia chooses three players. \u26ab\u26ab\u26ab Wake the player marked 1 and say 'The Al-Hadikhia has chosen', then the player's name, then 'Do you choose to live?' They either nod or shake their head. Put them to sleep and add or remove shrouds accordingly. Repeat for players marked 2 and 3. If all three players are now alive, add a shroud to all three."
+                "description": "The Al-Hadikhia chooses three players. \u26ab\u26ab\u26ab Wake the player marked 1 & say 'The Al-Hadikhia has chosen', then the player's name, then 'Do you choose to live?' They either nod or shake their head. Put them to sleep & add or remove shrouds accordingly. Repeat for players marked 2 & 3. If all three players are now alive, add a shroud to all three."
             },
             {
                 "default_alignment": "Evil"
@@ -1734,7 +1734,7 @@
                 "name": "Sage"
             },
             {
-                "description": "If the Demon killed the Sage, wake the Sage and point to 2 players, 1 of which is the Demon."
+                "description": "If the Demon killed the Sage, wake the Sage & point to 2 players, 1 of which is the Demon."
             },
             {
                 "default_alignment": "Good"
@@ -1776,7 +1776,7 @@
                 "name": "Huntsman"
             },
             {
-                "description": "The Huntsman might choose a player. \u26ab If that player was the Damsel: \n\tPut the Huntsman to sleep. Wake the Damsel and show them the YOU ARE info token and their new character token."
+                "description": "The Huntsman might choose a player. \u26ab If that player was the Damsel: \n\tPut the Huntsman to sleep. Wake the Damsel & show them the YOU ARE info token & their new character token."
             },
             {
                 "default_alignment": "Good"
@@ -1790,7 +1790,7 @@
                 "name": "Damsel"
             },
             {
-                "description": "If the Damsel was chosen by the Huntsman, show them the YOU ARE info token and their new character token."
+                "description": "If the Damsel was chosen by the Huntsman, show them the YOU ARE info token & their new character token."
             },
             {
                 "default_alignment": "Good"
@@ -1818,7 +1818,7 @@
                 "name": "Farmer"
             },
             {
-                "description": "If the Farmer died tonight, wake an alive good player. Show them the YOU ARE info token and a Farmer character token. Replace their previous token with the Farmer token."
+                "description": "If the Farmer died tonight, wake an alive good player. Show them the YOU ARE info token & a Farmer character token. Replace their previous token with the Farmer token."
             },
             {
                 "default_alignment": "Good"
@@ -2056,7 +2056,7 @@
                 "name": "Nightwatchman"
             },
             {
-                "description": "The Nightwatchman might choose a player. \u26ab Put the Nightwatchman to sleep. Wake the target and show the THIS PLAYER IS and Nightwatchman tokens and point to the Nightwatchman."
+                "description": "The Nightwatchman might choose a player. \u26ab Put the Nightwatchman to sleep. Wake the target & show the THIS PLAYER IS & Nightwatchman tokens & point to the Nightwatchman."
             },
             {
                 "default_alignment": "Good"
@@ -2070,7 +2070,7 @@
                 "name": "Cult Leader"
             },
             {
-                "description": "The Cult Leader might change alignment. If so, show the YOU ARE info token and a thumbs up or down for their new alignment."
+                "description": "The Cult Leader might change alignment. If so, show the YOU ARE info token & a thumbs up or down for their new alignment."
             },
             {
                 "default_alignment": "Good"
@@ -2196,7 +2196,7 @@
                 "name": "Hatter"
             },
             {
-                "description": "Wake Minions and Demons, allow them to choose new characters."
+                "description": "Wake Minions & Demons, allow them to choose new characters."
             },
             {
                 "default_alignment": "Good"
@@ -2210,7 +2210,7 @@
                 "name": "Travelers"
             },
             {
-                "description": "Tell any new travelers their alignment by showing the YOU ARE token and a thumbs up or down. If they are evil: \n\tShow the THIS IS THE DEMON token. Point to the Demon. Any night actions by travelers should be done now. "
+                "description": "Tell any new travelers their alignment by showing the YOU ARE token & a thumbs up or down. If they are evil: \n\tShow the THIS IS THE DEMON token. Point to the Demon. Any night actions by travelers should be done now. "
             },
             {
                 "default_alignment": "Neither"
@@ -2266,7 +2266,7 @@
                 "name": "Summoner"
             },
             {
-                "description": "Change the Summoner reminder token to the relevant night. If it is night 3, the Summoner chooses a player and a Demon. Put the Summoner to sleep. Wake the chosen player. Show the YOU ARE token, a thumbs  down and the chosen Demon token. "
+                "description": "Change the Summoner reminder token to the relevant night. If it is night 3, the Summoner chooses a player & a Demon. Put the Summoner to sleep. Wake the chosen player. Show the YOU ARE token, a thumbs  down & the chosen Demon token. "
             },
             {
                 "default_alignment": "Evil"

--- a/night.json
+++ b/night.json
@@ -1608,7 +1608,7 @@
                 "name": "Al-Hadikhia"
             },
             {
-                "description": "The Al-Hadikhia chooses 3 players. \u26ab\u26ab\u26ab Wake the player marked 1 & say 'The Al-Hadikhia has chosen', then the player's name, then 'Do you choose to live?' They either nod or shake their head. Put them to sleep & add or remove shrouds accordingly. Repeat for players marked 2 & 3. If all three players are now alive, add a shroud to all three."
+                "description": "The Al-Hadikhia chooses 3 players. \u26ab\u26ab\u26ab Wake the player marked 1 & say 'The Al-Hadikhia has chosen', then the player's name, then 'Do you choose to live?' They either nod or shake their head. Put them to sleep & add or remove shrouds accordingly. Repeat for players marked 2 & 3. If all 3 players are now alive, add a shroud to all 3."
             },
             {
                 "default_alignment": "Evil"

--- a/night.json
+++ b/night.json
@@ -206,7 +206,7 @@
                 "name": "Poppy Grower"
             },
             {
-                "description": "Do not do the Minion Info & Demon Info steps. Wake the Demon, show the THESE CHARACTERS ARE NOT IN PLAY info token & any three good character tokens that are not in play."
+                "description": "Do not do the Minion Info & Demon Info steps. Wake the Demon, show the THESE CHARACTERS ARE NOT IN PLAY info token & any 3 good character tokens that are not in play."
             },
             {
                 "default_alignment": "Good"
@@ -248,7 +248,7 @@
                 "name": "Snitch"
             },
             {
-                "description": "Wake each Minion. Show the THESE CHARACTERS ARE NOT IN PLAY token & three not-in-play character tokens. Put each Minion to sleep."
+                "description": "Wake each Minion. Show the THESE CHARACTERS ARE NOT IN PLAY token & 3 not-in-play character tokens. Put each Minion to sleep."
             },
             {
                 "default_alignment": "Good"
@@ -332,7 +332,7 @@
                 "name": "Engineer"
             },
             {
-                "description": "The Engineer might choose Minions or Demons. \u26ab If they do: \n\tPut the Engineer to sleep. Wake a targer, show them the YOU ARE token & their new character token, then put that target to sleep. Repeat for all players that changed characters."
+                "description": "The Engineer might choose Minions or Demons. \u26ab If they do: \n\tPut the Engineer to sleep. Wake a target, show them the YOU ARE token & their new character token, then put that target to sleep. Repeat for all players that changed characters."
             },
             {
                 "default_alignment": "Good"
@@ -528,7 +528,7 @@
                 "name": "Harpy"
             },
             {
-                "description": "The Harpy chooses two players. \u26ab\u26ab Put the Harpy to sleep. Wake the 1st target. Show the THIS CHARACTER SELECTED YOU token, the Harpy token, then point to the 2nd target."
+                "description": "The Harpy chooses 2 players. \u26ab\u26ab Put the Harpy to sleep. Wake the 1st target. Show the THIS CHARACTER SELECTED YOU token, the Harpy token, then point to the 2nd target."
             },
             {
                 "default_alignment": "Evil"
@@ -780,7 +780,7 @@
                 "name": "Knight"
             },
             {
-                "description": "Point to the two non-Demon players marked KNOW."
+                "description": "Point to the 2 non-Demon players marked KNOW."
             },
             {
                 "default_alignment": "Good"
@@ -794,7 +794,7 @@
                 "name": "Noble"
             },
             {
-                "description": "Point to all three players marked KNOW."
+                "description": "Point to all 3 players marked KNOW."
             },
             {
                 "default_alignment": "Good"
@@ -1188,7 +1188,7 @@
                 "name": "Engineer"
             },
             {
-                "description": "The Engineer might choose Minions or Demons. \u26ab If they do: \n\tPut the Engineer to sleep. Wake a targer, show them the YOU ARE token & their new character token, then put that target to sleep. Repeat for all players that changed characters."
+                "description": "The Engineer might choose Minions or Demons. \u26ab If they do: \n\tPut the Engineer to sleep. Wake a target, show them the YOU ARE token & their new character token, then put that target to sleep. Repeat for all players that changed characters."
             },
             {
                 "default_alignment": "Good"
@@ -1370,7 +1370,7 @@
                 "name": "Harpy"
             },
             {
-                "description": "The Harpy chooses two players. \u26ab\u26ab Put the Harpy to sleep. Wake the 1st target. Show the THIS CHARACTER SELECTED YOU token, the Harpy token, then point to the 2nd target."
+                "description": "The Harpy chooses 2 players. \u26ab\u26ab Put the Harpy to sleep. Wake the 1st target. Show the THIS CHARACTER SELECTED YOU token, the Harpy token, then point to the 2nd target."
             },
             {
                 "default_alignment": "Evil"
@@ -1608,7 +1608,7 @@
                 "name": "Al-Hadikhia"
             },
             {
-                "description": "The Al-Hadikhia chooses three players. \u26ab\u26ab\u26ab Wake the player marked 1 & say 'The Al-Hadikhia has chosen', then the player's name, then 'Do you choose to live?' They either nod or shake their head. Put them to sleep & add or remove shrouds accordingly. Repeat for players marked 2 & 3. If all three players are now alive, add a shroud to all three."
+                "description": "The Al-Hadikhia chooses 3 players. \u26ab\u26ab\u26ab Wake the player marked 1 & say 'The Al-Hadikhia has chosen', then the player's name, then 'Do you choose to live?' They either nod or shake their head. Put them to sleep & add or remove shrouds accordingly. Repeat for players marked 2 & 3. If all three players are now alive, add a shroud to all three."
             },
             {
                 "default_alignment": "Evil"


### PR DESCRIPTION
This is an update to reflect the differences between the app version with the physical version of Blood on the Clocktower.

The original branch was based on the app, but the tool is meant to create physical night order sheets. To reflect the properties of a physical version, the following changes have been made:

-The usage of "and" has been changed to "&" 
---This brings it in line with the printed versions of Trouble Brewing, Bad Moon Rising, and Sects and Violets.

-Dusk has been changed from "Start the night." to "Check that all eyes are closed. Some Fabled act."
---This brings it in line with the printed versions of Trouble Brewing, Bad Moon Rising, and Sects and Violets. Small liberties have been made, as the tool is adding a traveler night order reminder, and the physical versions say "Some Travellers & Fabled act." It's a design decision to remove "Travellers &" to not be redundant with the next line in the night order.

-Dawn has been changed from "Wait for a few seconds. End the Night Phase." to "Wait for a few seconds. Call for eyes open."
---This brings it in line with the printed versions of Trouble Brewing, Bad Moon Rising, and Sects and Violets.